### PR TITLE
Class rework for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
 # Scripting
 
-Scripting is programmed level-specific behavior that is currently defined by inputting command lines in the level files' script section. It has **three main components:**
+Scripting is programmed map specific behavior that is currently defined by lines in the .MAP file **\[script\]** section. It has **three main components:**
 
-- **Variables**
-- **Triggers**
-- **Events**
+- **Variables** are used to keep track of what's happening in the level.
+- **Triggers** check for when something specific occurs in the level.
+- **Events** are executed to alter gameplay in some way.
 
-**Variables** are used to keep track of what's happening in the level. **Triggers** check for when something specific occurs in the level. **Events** are executed to alter the level or player in some way.
+Variables, Triggers, and Events use [Classes](_pages/Classes) to deal with objects in the gameplay.
+
+Combined - script may respond to changes in the map and objects and record those changes or make gameplay changes based on interactions. For example when a miner in a vehicle drives over a location, the script could revel a new area of the map to explore.
+
+Via script, one can make significant changes to the map itself. Any tile can be turned into any other tile, allowing creation and changes to lakes, rivers, walls, spawning monsters, etc. There are a few limitations:
+- no changes to tile height. Height is set at map load time.
+- no new automatic undiscovered caverns may be generated.
+- no new miners and buildings, only the user is able to download miners or make new buildings.
+- no new landslides or erosions - they are set at map load time.
+
+It is possible via script to dramatically affect the gameplay - one could simulate lava and water floods, destroy bases and vehicles, spawn waves of monsters, change areas of the map to create new walls and paths, change available air, and many other things. You are mainly limited by your imagination and ability to convert an idea into working script. 
 
 Start by reviewing the [Scripting Structure](_pages/ScriptingStructure)
 
 Reserved words are here: [Reserved Words](_pages/ReservedWords)
 
-?> The game provide a handy log that tells you exactly what has occurred and if any errors happen.
+>The game provides a handy log that tells you exactly what has occurred and if any errors happen. Be aware that these are limited in number of events so fast timers or large scripts may exceed these limits making the debugging portion of your map more difficult. That said, scripts of tens of thousands of lines and thousands of event chains and variables do work as expected - so far no real limits have been discovered on size of script, number of event chains or variables.
 
 ![ShowLogs_Screenshot](_media/EditorScriptingOptions.png "Script Button")
 
@@ -20,13 +30,11 @@ Reserved words are here: [Reserved Words](_pages/ReservedWords)
 
 To assist you with scripting the Level Editor can display the Row, Column and Tile ID of the tile beneath the mouse cursor. This function is activated when you press the Script Interface button in the Level Editor.
 
-<p style="clear:both; float:none;" />
-
-!> If you notice something that's incorrect or require an update, come over to the **#Scripting** channel over on **[Discord](https://discord.gg/85k8JHz)**.
+>If you notice something that's incorrect or require an update, come over to the **#Scripting** channel over on **[Discord](https://discord.gg/85k8JHz)**.
 
 The script syntax will most likely confuse one at first - especially if one is familiar with modern free format programming languages. You cannot indent for readability - in general spaces are only allowed in a few specific places. There are no complex logical  conditions or expressions - in many ways those whom have had experience with assembly will notice many similarities.
 
-It is highly recommended that one review the demo scripts provided with the game to understand the syntax rules. If you are wondering if it is known how to do something - these would be the best place to start your search. These are found in the location where Manic Miners is installed in the following subdirectory path: ManicMiners\Levels\DEMO\Scripts
+>It is highly recommended that one review the demo scripts provided with the game to understand the syntax rules. If you are wondering if it is known how to do something - these would be the best place to start your search. These are found in the location where Manic Miners is installed in the following subdirectory path: ManicMiners\Levels\DEMO\Scripts
 
 Additional formating rules are found in this set of documents.
 

--- a/_pages/Classes.md
+++ b/_pages/Classes.md
@@ -1,124 +1,35 @@
-# Classes
+# Classes and Collections
 
-Not all classes of the game are known. See the bottom of this page on how you can learn more about them. Also don't forget to share anything you discover so that the wiki can be updated.
+The various objects in the game are usually associated with a class and/or collection. A collection is a wrapper for  multiple similar objects. Most Classes and Collections may be used with triggers to get notification related to that class or with conditions to test values in comparisons.
 
-## General information 
-A class can imply a declaration of an object type or a reference to a collection of objects. Currently classes can be divided in the following subcategories:
+Currently classes can be divided in the following subcategories:
 
-- Buildings
-- Vehicles
-- Items
-- Environmental
+- [Arrows](_pages/ClassesArrow)
+- [Buildings](_pages/ClassesBuildings)
+- [Creatures](_pages/classesCreatures)
+- [Miners](_pages/ClassesMiners)
+- [Timers](_pages/ClassesTimer)
+- [Vehicles](_pages/ClassesVehicles)
+- Environmental Collections
 
-### Declaration 
-A variable is declared a object of a certain type, for example a miner.
+## Environment Collections
 
-```mms
-	miner myMiner=1
-```
-
-### Collection 
-A group of objects of a specific type or category, for example miners or Support Stations
-
-```mms
-	miners
-	BuildingSupportStation_C
-```
-
-### Usage
-Declared objects or collections can be used together with triggers or properties, for example:
-
-```mms
-	when(myMiner.dead)[EVENT]
-```
-
-Trigger when the specified miner gets teleported back up.
-
-```mms
-	when(BuildingSupportStation_C.new)[EVENT]
-```
-
-Trigger when a Support Station is built.
-
-```mms
-	when(MyBuilding.click)((MyBuilding.power==true))[EVENT]
-```
-
-Trigger when a building is clicked but only if the building is currently powered and not turned off.
-<hr>
-Complete examples can be found in the pages for the larger classes and in the scripting examples page.
-
-## Class-types 
-A class can either be **curated** or **non-curated**, this refer to wheter the class have a predictable behaviour or not. Over time more classes will become curated as the game is developed further.
-
-### Curated
-Curated classes are officially supported, therefore they have predictable behaviour. For example, asking the game for the amount of Support Stations will return all constructed Support Stations, buildings under construction will not be counted. The following scripts are supported:
-
-- Count macros
-- Monitor events
-- Enable/Disable events
-
-### Non-curated 
-These classes can be used in some instances. These classes can have undefined return values for certain classes. For example, if you try to check how many Crystals are in the level, you will get both rechargable and charged crystals with no way of sorting them.
-
-## Class triggers 
-Class triggers are predefined triggers bound to specific object types. For triggers connected to larger classes, see their respective wiki-page. 
-
-```mms
-	CLASS.Trigger
-```
-
-Where CLASS is replaced with a collection or declared object and trigger with a valid trigger:
-
-|Command|Meaning|
-|----|----|
-|miner|Trigger if the event occur to any miner except miners named with variables.|
-|vehicle|Trigger if the event occur to any vehicle except vehicles named with variables.|
-|collection|Trigger when the specified event occur to any object of that collection.|
-|named object|Trigger if the event occur to that specific object.|
-
-?> Triggering a named object can also execute a trigger for a collection that includes that object.
-
-**List of common triggers**
+Environment Collections are special collections that are read only and are used as a macro, returning the number of discovered objects of that type. These collections do not have properties. TODO RESEARCH if any properties work.
 
 |Name|Description|
 |---|---|
-|click|Trigger when a object is clicked.|
-|dead|Trigger when a object dies or get teleported.|
-|hurt|Trigger when a object takes damage.|
-|new|Trigger when a object is created.|
+|Barrier_C|TODO.|
+|Crystal_C|Number of energy crystals active not yet stored. It is the number of green/purple ones on the ground and those being carried by miners or vehicles. Does not include any eaten by monsters.|
+|Dynamite_C|Number of dynamite outside of toolstore. They can be carried by a miner or dropped on the ground.|
+|ElectricFence_C|Number of electric fences placed on the map. TODO does it includes ones being carried?|
+|EventErosion_C|Number of ongoing erosions.|
+|EventLandslide_C|Number of ongoing landslides.|
+|NavModifierLava_C |Amount of lava tiles.|
+|NavModifierPowerPath_C|Amount of Power Path tiles, any type. Only finished paths.|
+|NavModifierRubble_C|Amount of Rubble tiles, any stage.|
+|NavModifierWater_C|Amount of water tiles.|
+|Ore_C|Number of Ore collected.  Can be changed by assigning **ore** macro with a new value.|
+|RechargeSeamGoal_C|Number of discovered recharge seams.|
+|Stud_C|Number of Studs collected. Can be changed by assigning **studs** macro with a new value.|
 
-## Known classes 
-### Larger classes 
-- [Buildings](_pages/ClassesBuildings)
-- [Vehicles](_pages/ClassesVehicles)
-- [Miners](_pages/ClassesMiners)
 
-### Smaller classes 
-
-**Items**
-
-|Name|Curated|Note|
-|---|---|---|
-|Crystal_C|No||
-|Ore_C|No||
-|Stud_C|No||
-|Barrier_C|No||
-|Dynamite_C|No||
-|ElectricFence_C|No|The fence item and fence building are two separate objects.|
-
-**Environmental**
-
-|Name|Curated|Note|
-|---|---|---|
-|EventErosion_C|No|Ongoing erosions. Only exists if they are active!|
-|EventLandslide_C|No|Ongoing landslides. Only exists if they are active!|
-|RechargeSeamGoal_C|No|Visible recharge seams. Can be used to count them.|
-|NavModifierLava_C |No|Amount of lava tiles.|
-|NavModifierWater_C|No|Amount of water tiles.|
-|NavModifierPowerPath_C|No|Amount of Power Path tiles, any type. Only finished paths.|
-|NavModifierRubble_C|No|Amount of Rubble tiles, any stage.|
-
-## More classes
-TODO - is this still valid?
-If you have an interest in a specific type of class to be added to this page, you can personally request them from the developer or check an older unpacked game build. In the unpacked build, every class has its own object. Please note that some class names have changed between different builds of the game.

--- a/_pages/ClassesArrow.md
+++ b/_pages/ClassesArrow.md
@@ -1,0 +1,25 @@
+# Arrow class
+
+Arrows are used for highlighting things in the world. Once you declare an arrow as a variable you can use these to move it around or hide it. The arrows have two usable components: A physical, hovering arrow, and a tile-sized highlight.
+
+An arrow is initialized by using the arrow variable type.
+
+```mms
+arrow MyArrow=color
+```
+
+Color may be one of: `black`, `blue`, `darkgreen`, `green`, `red`, `yellow`, `white`
+
+The arrow variable is then used by the following events.
+
+|Event|Syntax|Description|
+|---|---|---|
+|hidearrow|hidearrow:ARROW|The arrow is hidden until manually shown again.|
+|highlight|highlight:ROW,COLUMN,ARROW|Shows a highlight the size of a tile at ROW,COLUMN.|
+|highlightarrow|highlightarrow:ROW,COLUMN,ARROW|Executes both showarrow and highlight at once.|
+|showarrow|showarrow:ROW,COLUMN,ARROW|Shows the designated arrow at the tile ROW,COLUMN.|
+
+It is highly recommended to review the Arrow examples in ManicMiners\Levels\DEMO\Scripts
+
+Arrows were primarily put in for the tutorials and have limited use outside of tutorial type of maps - but it does allow the user to be notified of something they need to pay attention to by the map designer.
+

--- a/_pages/ClassesBuildings.md
+++ b/_pages/ClassesBuildings.md
@@ -4,17 +4,21 @@ The building class is used to create a reference to a building. With that refere
 ## Declaration
 
 ```mms
-building MyStore=2,14  # existing building at row 2, col 14 assigned to variable
-building MyStore       # will be assigned later.
+building MyBuilding=2,14  # existing building at row 2, col 14 assigned to variable
+building MyBuilding       # will be assigned later.
 ```
 
 - Building variables not assigned may later be assigned via `=lastbuilding` or `savebuilding`.
 - Building variables may be assigned to each other.
 - Unassigned building variables cannot be used in a trigger.
-- It is common to use a building collection class in the trigger and use `=lastbuilding` or `savebuilding` in an event chain.
+- It is common to use a building collection class in the trigger and use `=lastbuilding` or `savebuilding` in an event chain to get the building that caused the trigger.
 - Undiscovered buildings and their triggers are inactive until they are discovered.
 
-## Triggers
+## Properties
+These are the class properties specific to buildings.  Properties start with the dot `.` character followed by the name after the object variable or collection name.
+
+## Trigger properties
+>These properties are for use in triggers. They cannot be used in assignments or conditions.
 
 |Name|Description|
 |---|---|
@@ -28,6 +32,7 @@ building MyStore       # will be assigned later.
 |poweron|Trigger when power is activated for a building.|
 
 ## Properties
+>These properties are read-only and are used as a macro, returning a value. They may be used in assignment events on the right side, or in conditions for testing. These cannot be used on collections, they must be used with a specific building.
 
 |Property|Type|Note|
 |---|---|---|
@@ -38,22 +43,25 @@ building MyStore       # will be assigned later.
 |id|int|Returns the ID the building.|
 |ispowered|bool|Same as power.|
 |level|int|Returns upgrade level of the building.|
-|power|bool|Returns TRUE if the building has power, FALSE if it doesn't.|
+|power|bool|Returns `true` if the building has power, `false` if it doesn't.|
 |powered|bool|Same as power.|
 |row|int|Returns row of the building.|
-|stamina|int|same as hp.|
+|stamina|int|Same as hp.|
 |tile|int|TileID for the initial place point of the building.|
-|tileid|int|same as tile.|
-|X|int|Column, 300 values per cell|
-|Y|int|Row, 300 values per cell|
-|Z|int|Height, 300 values per cell|
+|tileid|int|Same as tile.|
+|X|int|Column, 300 values per map tile.|
+|Y|int|Row, 300 values per map tile.|
+|Z|int|Height, 300 values per map tile.|
 
 
 ## Collections 
-Each native building class has their own collection. When used by itself the collection return the total number of constructed buildings of that type. The collection can utilize triggers but not properties. Buildings must be discovered, undiscovered buildings are inactive until they are discovered.
+Each native building class has their own collection. When used by itself without a trigger property, it is treated as a read-only macro returning the total number of constructed buildings of that type. Collections may only use trigger properties.
+
+>Undiscovered buildings are inactive and do not receive triggers until they are discovered.
 
 |Name|Note|
 |---|---|
+|building|Refers to all buildings.|
 |BuildingDocks_C|Docks.|
 |BuildingElectricFence_C|Electric Fences.|
 |BuildingGeologicalCenter_C|Geological Centers.|
@@ -67,13 +75,13 @@ Each native building class has their own collection. When used by itself the col
 |BuildingToolStore_C|Tool Stores.|
 |BuildingUpgradeStation_C|Upgrade Stations.|
 
-> `building` keyword may also be used as a collection in triggers.  It is a special collection in that it cannot be used as a macro to return number of buildings but can be used in triggers. To detect every new building:
+> `building` is a special collection in that it cannot be used as a macro to return number of buildings but can be used in triggers. To detect every new building:
 ```mms
-when(building.new)[MyNewBuildingChain]
+when(building.new)[MyNewBuildingChain]  # call event chain when any building is created.
 ```
 
 ## Macros
-These are not collections. They return the number of objects as an int.
+These are not collections. They return the number of objects as an int. They may be used in assignments on the right side or in conditions.
 
 |Name|Description|
 |---|---|
@@ -82,11 +90,12 @@ These are not collections. They return the number of objects as an int.
 |electricfence|Number of Fences.|
 |ElectricFence_C|Number of fence objects. Not a collection.|
 |geologicalcenter|Number of Geological Centers.|
-|mininglaser|Number of Geological Centers.|
+|mininglaser|Number of Mining Lasers.|
 |orerefinery|Number of Ore Refineries.|
 |powerstation|Number of Power Stations.|
+|superteleport|Number of Super Teleports.|
 |supportstation|Number of Support Stations.|
-|teleportpad|Numbewr of Teleport Pads.|
+|teleportpad|Number of Teleport Pads.|
 |toolstore|Number of Tool Stores.|
 |upgradestation|Number of Upgrade Stations.|
 
@@ -96,17 +105,17 @@ A collection can be used together with the disable event in order to prevent the
 ```mms
 disable:BuildingSuperTeleport_C
 enable:BuildingSuperTeleport_C
-disable:buildings   # notice buildings is special keyword - not a macro.
+disable:buildings   # buildings is a special keyword referring to all buildings in this context.
+enable:buildings    # buildings is a special keyword referring to all buildings in this context
 ```
 
 ## Examples
-### Count buildings
+### Display number of support stations after every one is created.
 
 ```mms
-when(drill:2,2)[msg:BuildingSupportStation_C]
+when(BuildingSupportStation_C.new)[msg:BuildingSupportStation_C]
 ```
 
-When you drill a wall at position 2,2 a number indicating the total amount of constructed Support 	Stations will be displayed.
 
 ### Click a building
 

--- a/_pages/ClassesCreatures.md
+++ b/_pages/ClassesCreatures.md
@@ -13,8 +13,11 @@ creature MyCreature    # will be assigned later by lastcreature or =.
 - It is common to use a creature collection class in the trigger and use `=lastcreature` or `savecreature` in an event chain.
 - Undiscovered creatures and their triggers are inactive until they are discovered.
 
+## Properties
+These are the class properties specific to creatures.  Properties start with the dot `.` character followed by the name after the object variable or collection name.
 
-## Triggers
+## Trigger Properties
+>These properties are for use in triggers. They cannot be used in assignments or conditions.
 
 |Name|Description|
 |---|---|
@@ -22,6 +25,8 @@ creature MyCreature    # will be assigned later by lastcreature or =.
 |new|Trigger when creature is emerged. Only used with collections.
 
 ## Properties
+
+>These properties are read-only and are used as a macro, returning a value. They may be used in assignment events on the right side, or in conditions for testing. These cannot be used on collections, they must be used with a specific creature.
 
 |Property|Type|Note|
 |---|---|---|
@@ -39,7 +44,9 @@ creature MyCreature    # will be assigned later by lastcreature or =.
 |Z|int|Height, 300 values per cell|
 
 ## Collections 
-Each native creature class has their own collection. When used by itself the collection acts like a macro and returns the total amount of creatures of that type. The collection can be used in triggers.
+Each native creature class has their own collection. When used by itself without a trigger property, it is treated as a read-only macro returning the total number of creatures of that type.  Collections may only use trigger properties.
+
+>Undiscovered creatures are inactive and do not receive triggers until they are discovered.  Creatures cannot be spawned into undiscovered areas.
 
 |Name|Description|
 |---|---|
@@ -59,6 +66,8 @@ Each native creature class has their own collection. When used by itself the col
 > There are two names for each creature collection, it is recommend to use the long name for clarity. The short names are for compatibility with older maps.
 
 ## Macros
+These are not collections. They return the number of objects as an int. They may be used in assignments on the right side or in conditions.
+
 - `creatures` macro returns the number of all creatures.
 - `hostiles` macro returns the number of monsters and slugs.
 
@@ -74,14 +83,14 @@ The following events control automatic pseudo random monster spawning in waves.
 |startrandomspawn:COLLECTION|Start the random spawn for the given collection.|
 |stoprandomspawn:COLLECTION|Stop the random spawn for the given collection.|
 
-Mainly added for slimy slugs, it work on monsters also.  Creatures are spawned on a random basis in waves until the the spawncap number of creatures are active. Creatures are spawned from any random valid emergeable location in the discovered areas of the map.
+Mainly added for slimy slugs, it work on monsters also.  Creatures are spawned on a random basis in waves until the the spawncap number of creatures are active. Creatures are spawned from any random valid  location in the discovered areas of the map. Valid locations are non-corner, not reenforced walls of dirt, loose rock, or hard rock.
 
 If you want to have control over the spawn locations, you have to write your own logic using emerge or use the visual block triggers in the map editor.
 
 Emerge event will allow you the ability to emerge a single creature from a given location and an optional radius
 
 ## Making a creature flee
-Use the flee: event to cause a creature to flee to that location.  If you use a collection, all active monsters of that type will flee to that location. The location must be a valid location for the creature, once it gets there it expects to be able to leave the map as it normally would. Thus for slimy slugs, it must be a slug hole. For monsters it must be next to a wall that is emergeable or solid rock.
+Use the flee: event to cause a creature to flee to that location.  If you use a collection, all active monsters of that type will flee to that location. The location must be a valid location for the creature, once it gets there it expects to be able to leave the map as it normally would. Thus for slimy slugs, it must be a slug hole. For monsters it must be next to a non-corner wall that is not reenforced of dirt, loose rock, hard rock, or solid rock.
 
 ```mms
 flee:MyMonster,row,col

--- a/_pages/ClassesMiners.md
+++ b/_pages/ClassesMiners.md
@@ -13,8 +13,12 @@ miner Charlie     # miner unassigned, will be assigned later.
 - It is common to use `miner` collection class in the trigger and use `=lastminer` or `save` in an event chain.
 - Undiscovered miners and their triggers are inactive until they are discovered.
 
+## Properties
+These are the class properties specific to miners.  Properties start with the dot `.` character followed by the name after the object variable or collection name.
 
-## Triggers 
+
+## Trigger Properties 
+>These properties are for use in triggers. They cannot be used in assignments or conditions.
 
 |Name|Description|
 |---|---|
@@ -25,6 +29,7 @@ miner Charlie     # miner unassigned, will be assigned later.
 |levelup|Trigger when miners upgrade level is increased.|
 
 ## Properties
+>These properties are read-only and are used as a macro, returning a value. They may be used in assignment events on the right side, or in conditions for testing. These cannot be used on collections, they must be used with a specific miner.
 
 |Property|Type|Note|
 |---|---|---|
@@ -45,12 +50,15 @@ Note: that there does not appear to be any way to detect miners skills.
 
 ## Collections
 
-> `miner` keyword may also be used as a collection in triggers.  It is a special collection in that it cannot be used as a macro to return number of miners but can be used in triggers. To detect every new miner:
+>Undiscovered miners are inactive and do not receive triggers until they are discovered. There is only a single special collection for miners.
+
+
+`miner` keyword may be used as a collection in triggers.  It is a special collection in that it cannot be used as a macro to return number of miners but can be used in triggers. To detect every new miner:
 ```msg
 when(miner.new)[MyNewMinerChain]
 ```
 
-The `miners` macro returns the number of miners.
+The `miners` read-only macro returns the number of miners.
 
 ## enable / disable
 The `enable` and `disable` events support disabling transporting of miners and re-enabling. See [Events](_pages/Events).

--- a/_pages/ClassesTimer.md
+++ b/_pages/ClassesTimer.md
@@ -1,0 +1,29 @@
+# Timers
+
+Periodic timers are created by either the visual block system or use of a timer variable. Once a timer is created, it will continue to fire on the given interval until the user exits the map or stoptimer event is used.
+
+When the game is paused, timers are suspended.
+
+ The interval values may be floating point numbers and the engine does support sub second timings. Naturally as timers fire faster or the more timers are active - internal overhead associated with them increases. That said, using timers is always more efficient than using the `tick` Event Chain.
+
+Timers are control by a timer variable
+
+```mms
+timer MyTimer=DELAY,MIN,MAX,EVENTCHAIN
+```
+
+Defines a variable of type timer with the given name MyTimer. It will wait delay seconds to start, and will fire between min seconds and max seconds after the last firing, calling the given eventchain. Timer values may be int or float.
+
+See Levels\DEMO\Scripts\demotimers.dat for examples.
+
+
+Using a timer variable allows use of `stoptimer` and `starttimer` events.
+
+|Syntax|Description|
+|---|---|
+|starttimer:name|name is timer variable, its timer is started if it was stopped.|
+|stoptimer:name|name is a timer variable, its timer is stopped if it is running.|
+
+Timers continue to fire even after losing the game. If you are manually controlling the win/lose cases, it may be a good idea to use stoptimer on any active timers when the player loses the map.
+
+After wining the map, players may decide to continue to play and the timers will continue to fire. You may need to account for this to prevent any map lose messages after winning.

--- a/_pages/ClassesVehicles.md
+++ b/_pages/ClassesVehicles.md
@@ -1,5 +1,6 @@
 # Vehicle Class
 The vehicle class is used to create a reference to a vehicle. With that reference you can then call on and use triggers and properties exclusive to that vehicle. You may also refer to a vehicle collection where you may use triggers connected to every vehicle of a specific type.
+
 ## Declaration
 
 ```mms
@@ -13,8 +14,11 @@ vehicle Sofia      # unassigned vehicle, will be assigned later
 - It is common to use a vehicle collection class in the trigger and use `=lastvehicle` or `savevehicle` in an event chain.
 - Undiscovered vehicles and their triggers are inactive until they are discovered.
 
-## Triggers 
-Triggers may be used on a single object variable or on collections.
+## Properties
+These are the class properties specific to vehicles.  Properties start with the dot `.` character followed by the name after the object variable or collection name.
+
+## Trigger Properties
+>These properties are for use in triggers. They cannot be used in assignments or conditions.
 
 |Name|Description|
 |---|---|
@@ -26,7 +30,7 @@ Triggers may be used on a single object variable or on collections.
 |upgrade|Trigger when vehicle is upgraded.|
 
 ## Properties
-Properties may only be used on a single object, they are not for use with collections.
+>These properties are read-only and are used as a macro, returning a value. They may be used in assignment events on the right side, or in conditions for testing. These cannot be used on collections, they must be used with a specific vehicle.
 
 |Property|Type|Note|
 |---|---|---|
@@ -47,26 +51,7 @@ Properties may only be used on a single object, they are not for use with collec
 Note: there is no level property on vehicles to query upgrades
 
 ## Collections
-Each native vehicle class has their own collection. When used by itself the collection return the total amount of constructed vehicles of that type. The collection can utilize triggers but not properties.
-
-> `vehicle` keyword may also be used as a collection in triggers.  It is a special collection in that it cannot be used as a macro to return number of vehicles but can be used in triggers. To detect every new vehicle:
-```msg
-when(vehicle.new)[MyNewVehicleChain]
-```
-
-
-### Disable or enable a vehicle
-A collection can be used together with the disable event in order to prevent the player from teleporting down the specified vehicle. Likewise the enable event will re-allow a player to teleport the specified vehicle. See [Events](_pages/Events).
-
-```mms
-disable:VehicleChromeCrusher_C
-enable:VehicleChromeCrusher_C
-disable:vehicles
-```
-
-### List of collections 
-Collections may be used by as a macro to return an int the is the number of those objects in the map. Undiscovered objects are not included in the count.
-Collections may be used as a trigger.
+Each native vehicle class has their own collection. When used by itself without a trigger property, it is treated as a read-only macro returning the total number of vehicles of that type. Collections may only use trigger properties.
 
 |Name|Description|
 |---|---|
@@ -82,6 +67,12 @@ Collections may be used as a trigger.
 |VehicleSMLC_C|Small Mobile Laser Cutter|
 |VehicleTunnelScout_C|Tunnel Scouts|
 |VehicleTunnelTransport_C|Tunnel Transports|
+
+> `vehicle` keyword may also be used as a collection in triggers.  It is a special collection referring to all vehicles. It cannot be used as a macro to return number of vehicles but can be used in triggers. To detect every new vehicle:
+```msg
+when(vehicle.new)[MyNewVehicleChain]
+```
+
 
 ## Macros
 These are not collections. They return the number of objects as an int.
@@ -101,6 +92,17 @@ These are not collections. They return the number of objects as an int.
 |tunnelscout|Number of Tunnel Scouts.|
 |tunneltransport|Number of Tunnel Transports.|
 |vehicles|Number of vehicles.|
+
+
+### Disable or enable a vehicle
+A collection can be used together with the disable event in order to prevent the player from teleporting down the specified vehicle. Likewise the enable event will re-allow a player to teleport the specified vehicle. See [Events](_pages/Events).
+
+```mms
+disable:VehicleChromeCrusher_C
+enable:VehicleChromeCrusher_C
+disable:vehicles      # vehicles is a special keyword to refer to all vehicles in this context
+enable:vehicles       # vehicles is a special keyword to refer to all vehicles in this context
+```
 
 
 ## Examples 

--- a/_pages/Events.md
+++ b/_pages/Events.md
@@ -15,7 +15,7 @@ Events describe to the game what you want it to do when a trigger is activated. 
 |---|---|---|
 |addrandomspawn|addrandomspawn:COLLECTION,MINTIME,MAXTIME|Configure random spawn of a creature collection. MINTIME and MAXTIME define a random time in float seconds between each spawn wave.|
 |disable|disable:COLLECTION|Disable the given object type. See description below for list of types|
-|drill|drill:ROW,COLUMN|Drill tile ROW,COLUMN. It will play the appropriate effect and place rubble, ignoring what tile it is.*|
+|drill|drill:ROW,COLUMN|Drill tile ROW,COLUMN. It will play the appropriate effect and place rubble. All wall tiles can be drilled with this event including those not normally drillable.
 |emerge|emerge:ROW,COLUMN,DIRECTION,COLLECTION,DISTANCE|Causes a monster to emerge. ROW,COLUMN integers are desired tile. DIRECTION is one of A,N,S,E,W. COLLECTION is one of CreatureRockMonster_C, CreatureLavaMonster_C, CreatureIceMonster_C. DISTANCE is integer distance from ROW,COLUMN to find emergeable tile to use.|
 |enable|enable:COLLECTION|Enable the given object type. See description below for list of types.|
 |flee|flee:OBJECT,ROW,COL|Causes the given monster object (or collection) to flee to the given tile. Once there, the Creature will try and escape as it normally does. Collections will cause all creatures of that collection to flee to that location.|
@@ -24,11 +24,11 @@ Events describe to the game what you want it to do when a trigger is activated. 
 |highlight|highlight:ROW,COLUMN,ARROW|Shows a highlight the size of a tile at ROW,COLUMN.|
 |highlightarrow|highlightarrow:ROW,COLUMN,ARROW|Executes both showarrow and highlight at |kill|kill:VARIABLE|kill will transport up the given object, either building, miner, or vehicle. If object also has a .dead trigger, that trigger will fire.|
 |lose|lose:MsgStr|Player loses the level with the message defined by string MsgStr. If no string is supplied, they lose the level anyway.|
-|message|msg:MsgStr|Display the message string MsgStr, as defined above. Message is added to the list of message in the message area of the user interface.|
+|message|msg:MsgStr|Display the message string MsgStr, as defined above. Message is added to the list of message in the message area of the user interface. You must use a string variable or a numeric value that will be displayed as a string - you cannot use a string constant.|
 |pan|pan:ROW,COLUMN|The player's camera pans to the tile at ROW,COLUMN. The view direction does not change.|
 |pause|pause|Pauses the game. A bit weird right now as it stops the camera lag effect. The player can unpause with the pause button (P)|
 |place|place:ROW,COLUMN,ID|Place a tile with the specified [ID](_pages/LevelDataFile) in the level at the coordinates given by ROW and COLUMN.__**__|
-|qmessage|qmsg:MsgStr|Display the message string MsgStr, wait for message to be acknowledged by user|
+|qmessage|qmsg:MsgStr|Display the message string MsgStr, wait for message to be acknowledged by user. You must use a string variable or a numeric value that will be displayed as a string - you cannot use a string constant.|
 |save|[save:MINERVAR]|Saves the last miner unit who activated a trigger into a variable.|
 |savebuilding|savebuilding:BUILDINGVAR|Saves the last building that activated a trigger into given building variable.|
 |savecreature|savecreature:CREATUREVARIABLE|Save last creature that activated a trigger into a creature variable.|
@@ -48,32 +48,27 @@ Events describe to the game what you want it to do when a trigger is activated. 
 |wait|wait:GAME_SECONDS|Ask the game to wait a set amount of seconds before executing the next command. Only supported within an event chain. Scales with game speed. While waiting the engine continues to run and script responds to events - so it is possible to re-entrant into the waiting event. You are responsible for handling this case.|
 |win|win:MsgStr|Player wins the level with the message defined by string MsgStr. If no string is supplied, they win the level anyway.|
 
+<br>__**__ If you place a wall on top of a miner or vehicle, they will just phase through the ground. This behaviour will be updated in the future to simply bury them until they are dug out.
 
-?> __*__ Drilling will get fixed later to check that the tile can actually be drilled. <br>__**__ If you place a wall on top of a miner or vehicle, they will just phase through the ground. This behaviour will be updated in the future to simply bury them until they are dug out.
-
-## Player interaction
-!> These events interact directly with the player and should be used with caution.
+## Unknown Events
+> These are events that appear to be known by the engine but no one has figured out the syntax and behavior.
 
 |Event|Syntax|Description|
 |---|---|---|
-|pause|pause|Pauses the game. A bit weird right now as it stops the camera lag effect. The player can unpause with the pause button (P)|
+|landslide|unknown|unknown, landslide is a reserved word.|
+
+## Player interaction
+> These events interact directly with the player and should be used with caution.
+
+|Event|Syntax|Description|
+|---|---|---|
+|pause|pause|Pauses the game. When the game is paused, time does not pass, timers do not fire. The player can unpause with the pause button (P) or by unpause event.|
 |reset|reset|Resets the player's selection (equivalent to a right-click)|
 |resetspeed|resetspeed|Loads the game speed from settings again.|
 |resume|resume|Same as unpause.|
 |speed|speed:NEW_SPEED|Sets the game speed to NEW_SPEED temporarily. The speed does not save and should only be used in specific instances, like a slow motion sequence. Does not prevent the player from increasing the speed in settings.|
-|unpause|unpause|Resumes the game if paused. Note that since time does not pass while the game is paused, even with truewait, this can only be called via player interaction such as clicks.|
+|unpause|unpause|Resumes the game if paused. Note that since time does not pass while the game is paused and timers are suspended - this can only be called via player interaction such as clicks.|
 
-## Arrow events
-Arrows are used for highlighting things in the world. Once you declare an arrow as a variable you can use these to move it around or hide it. The arrows have two usable components: A physical, hovering arrow, and a tile-sized highlight.
-
-|Event|Syntax|Description|
-|---|---|---|
-|hidearrow|hidearrow:ARROW|The arrow is hidden until manually shown again.|
-|highlight|highlight:ROW,COLUMN,ARROW|Shows a highlight the size of a tile at ROW,COLUMN.|
-|highlightarrow|highlightarrow:ROW,COLUMN,ARROW|Executes both showarrow and highlight at once.|
-|showarrow|showarrow:ROW,COLUMN,ARROW|Shows the designated arrow at the tile ROW,COLUMN.|
-
-It is highly recommended to review the Arrow examples in ManicMiners\Levels\DEMO\Scripts
 
 ## Disable/Enable events
 Disable/Enable is used to control what the player can and cannot do in the current level. One example might be that you don't want the player to use flying vehicles, in which case you can disable the Tunnel Scout and Tunnel Transport manually. The syntax looks like this:
@@ -90,7 +85,7 @@ where COLLECTION can be one of the following:
 |buildings|Toggle player's ability to teleport buildings.|
 |VEHICLENAME_C|Toggle player's ability to teleport a specific vehicle class.|
 |BUILDINGNAME_C|Toggle player's ability to teleport a specific building class.|
-|light/lights|Toggle all ambient light in the cavern. The player cannot override this. Vehicles have floodlights and some miner helmets have a light.|
+|light/lights|Toggle all ambient light in the cavern. The player cannot override this. Vehicles have floodlights that still show and some miner helmets have a light that will still show.|
 
 Example - this event chain will turn off any ability to transport miners, vehicles, buildings or use explosives:
 
@@ -121,7 +116,7 @@ Math events are complete events thus you cannot use math operators inside of a c
 
 You cannot combine multiple math operators. Only a single math operation at a time - there is no support for complex operations or ordering.
 
-While the engine will convert bool to int automatically - it is poor programming practice to mix bool and integers. Bools should only set to true/false and only tested against true/false.
+While the engine will convert bool to int automatically - it is poor programming practice to mix bool and integers. bool should only set to true/false and only tested against true/false.
 
 Strings only support + and += operations. The values of int and float variables are converted to strings. 
 
@@ -134,16 +129,16 @@ Since place and drill only modify a single tile - the game collects up all of th
 
 Note that a wait event also allows processing of all queued place events. Thus one can do animations - change some tiles - wait - change more tiles - wait, etc.
 
-The engine has a limit on the number of tiles that may be modified in the context of a trigger - that value is somewhere around 630 tiles. Non-deterministic results may happen changing too many tiles. This can be seen in the map editor where a range goes red when it is too large.
+The engine has a limit on the number of tiles that may be modified in the context of a trigger - that value is somewhere around 630 tiles. Non-deterministic results may happen changing too many tiles. This can be seen in the map editor where a range goes red when it is too large. Script that changes hundreds of tiles may cause a lag spike to the user and thus one may find better interactivity by limiting updates to smaller number of tiles and doing them over a time period.
 
 Water and lava are special tiles. They require custom textures and the engine is not able to mix new water and lava tiles in the context of the same trigger. Also trying to place either water or lava tile(s) when other tiles are changed has the same limitation.  Thus in the context of a single trigger you may only place
 - only water
 - only lava
 - only non water/lava.
 
-Attempts to do more than one of these has non-deterministic results.
+Attempts to do more than one of these has non-deterministic results.  One must be aware that multiple triggers may fire around the same time and the same restrictions still apply so beware of these cases when modifying maps. Thus it is a good idea after using place to change tiles - if any of them could be water/lava, using a wait event with a short timeout is a good idea to allow the changes to be processed.
 
-A drill event is similar to a place event, so if you use drill, you cannot also place either water or lava from the same trigger.
+A drill event is similar to a place event, so if you use drill, you cannot also place either water or lava from the same trigger without a wait event.
 
 You cannot use place to create new undiscovered caverns. Undiscovered caverns are only setup by the engine during map load and are fixed by the time script starts executing.
 A currently undiscovered cavern may have its walls modified (for example changing from solid rock to loose rock) since you are not changing the undiscovered space.

--- a/_pages/LevelDataFile.md
+++ b/_pages/LevelDataFile.md
@@ -5,7 +5,7 @@ The Level data file contains all the information needed to generate a level incl
 
 |ID|Name|
 |---|---|
-0|UNUSED|
+0|UNUSED blank|
 1|Ground|
 2|Rubble Level 1|
 3|Rubble Level 2|
@@ -59,15 +59,23 @@ The Level data file contains all the information needed to generate a level incl
 51|Recharge seam corner|
 52|Recharge seam edge|
 53|Recharge seam intersect|
-54|ERROR|
-55|ERROR|
-56|ERROR|
-57|ERROR|
+54|Undefined|
+55|Undefined|
+56|Undefined|
+57|Undefined|
 58|Roof|
-59|ERROR|
+59|Undefined|
 60|Fake rubble 1|
 61|Fake rubble 2|
 62|Fake rubble 3|
 63|Fake rubble 4|
 64|Cliff type 1 (experimental)|
 65|Cliff type 2 (experimental)|
+
+- Tiles over 65 are undefined.
+- Tiles over 100 are hidden cavern tiles. These are the normal ground tiles with +100 added to them indicating they are hidden and will be discovered. Walls within a hidden cavern do not have the +100 added to them.
+- Reenforced walls tiles have +50 added to them.
+
+>Some of the undefined tiles have different textures depending on the theme and some are simply interesting.
+
+>All undefined tiles are subject to change but that said no new changes to tile textures are planned.

--- a/_pages/Macros.md
+++ b/_pages/Macros.md
@@ -19,7 +19,8 @@ There exist variable names that are reserved as macros. When used in Scripting, 
 |clock|float|Returns the amount of seconds that have passed since the level. Same as time.|
 |ConstructedBuilding|building|Return the last constructed building.|
 |creatures|int|Returns number of creatures.|
-|crystals|int|Returns the crystal count.|
+|crystals|int|Returns the stored crystal count.|
+|Crystal_C|int|Returns the unstored crystal count.|
 |crystal_seam|int|Returns tile id of a crystal seam (42).|
 |dirt|int|Returns tile id of dirt (26).|
 |docks|int|Returns number of Docks.|
@@ -27,7 +28,7 @@ There exist variable names that are reserved as macros. When used in Scripting, 
 |ElectricFence_C|int|Returns number of fence objects. Not a collection.|
 |erosionscale|float|Returns or sets the erosionscale.|
 |geologicalcenter|int|Returns number of Geological Centers.|
-|get(ROW)(COLUMN)|int|Returns the tile ID of the specified coordinates.|
+|get(ROW)(COLUMN)|int|Returns the tile ID of the specified coordinates. ROW COLUMN are ints.|
 |granitegrinder|int|Return Number of Granite Grinders.|
 |hard_rock|int|Returns tile id of hard rock (34).|
 |hostiles|int|Returns number of hostile units.|
@@ -48,7 +49,7 @@ There exist variable names that are reserved as macros. When used in Scripting, 
 |ore_seam|int|Returns tile id of an ore seam (46).|
 |powerstation|int|Returns number of Power Stations.|
 |progress_path|int|Returns tile id of a progress path (13).|
-|random(MIN)(MAX)|float|Return random number from MIN to MAX.|
+|random(MIN)(MAX)|float|Return random number from MIN to MAX. MIN MAX are floats.|
 |rapidrider|int|Return number of Rapid Riders.|
 |slugs|int|Returns number of slimy slugs.|
 |slug_hole|int|Returns tile id of slimy slug hole (12).|
@@ -69,7 +70,7 @@ There exist variable names that are reserved as macros. When used in Scripting, 
 
 All collection classes may be used as a macro and they will return an int that is the number of objects in that collection.
 
-[building](_pages/ClassesBuildings), [creature](_pages/ClassesCreatures), [miner](_pages/ClassesMiners)and [vehicle](_pages/ClassesVehicles) classes have data fields that allow querying properties on them and they are also treated as a macro. See each class type for the list of data fields it supports.
+[building](_pages/ClassesBuildings), [creature](_pages/ClassesCreatures), [miner](_pages/ClassesMiners) and [vehicle](_pages/ClassesVehicles) classes have data fields that allow querying properties on them and they are also treated as a macro. See each class type for the list of data fields it supports.
 
 
 ## Macros that may be modified
@@ -78,7 +79,7 @@ A few macros allow modification which changes game play. These may be used on th
 
 |Macro|Assignment Type|Function|
 |----|----|----|
-|air|int|Set current amount of air. Will be capped between zero and map limit.|
+|air|int|Set current amount of air. Will be capped between zero and map limit. Setting to low numbers may lose the map.|
 |crystals|int|Set amount of crystals collected.|
 |erosionscale|float|Set erosion scaling.|
 |ore|int|Set amount of ore collected.|
@@ -86,6 +87,7 @@ A few macros allow modification which changes game play. These may be used on th
 
 
 ### Air
+
 Air is specified in miner seconds. One unit of air is the amount of air a single miner will use every game second. Thus one-hundred will support ten miners for ten game seconds or one miner for one-hundred game seconds.
 
 When air gets to zero - the player loses the map.

--- a/_pages/ReservedWords.md
+++ b/_pages/ReservedWords.md
@@ -45,9 +45,9 @@ These are not case sensitive since variable names and event chain names are not 
 |CreatureSmallSpider_C|Collection|Spider objects.|
 |CreatureSlimySlug_C|Collection|Slimy Slug objects.|
 |creatures|Macro|Number of creatures.|
-|Crystal_C|Collection|All crystals include those needing recharge.|
+|Crystal_C|Collection|Unstored crystals include those needing recharge.|
 |crystal_seam|Macro|Tile ID of a crystal seam (42).|
-|crystals|Macro|Crystal count.|
+|crystals|Macro|Stored Crystal count.|
 |darkgreen|Color|Arrow colors.|
 |dead|Data Field Trigger|Trigger when object is dead.|
 |dirt|Macro|Tile ID of dirt (26).|
@@ -93,6 +93,7 @@ These are not case sensitive since variable names and event chain names are not 
 |integer|Variable|Integer number.|
 |ispowered|Data Field|Same as power.|
 |kill|Event|Kill object.|
+|landslide|Event|Unknown.|
 |laser|Trigger|Trigger when wall destroyed by laser.|
 |laserhit|Trigger|Trigger when wall hit by laser.|
 |lastbuilding|Macro|Last building that activated a trigger.|
@@ -169,6 +170,7 @@ These are not case sensitive since variable names and event chain names are not 
 |Stud_C|Collection|All building studs.|
 |studs|Macro|Building Stud count.|
 |string|Variable|Text.|
+|superteleport|Macro|Number of Super Teleports.|
 |supportstation|Macro|Number of Support Stations.|
 |teleportpad|Macro|Numbewr of Teleport Pads.|
 |tick|Event Chain|Called on every engine tick. Not recommended.|

--- a/_pages/Variables.md
+++ b/_pages/Variables.md
@@ -2,9 +2,19 @@
 
 Variables are containers for objects such as numbers and text. You can use them to keep track of values such as how many times the player has reinforced walls or how many caverns they have opened. Integer and float values are similar to what one would expect from any programming language.
 
+Variables also are used with many classes:
+
+- [arrow](_pages/ClassesArrow)
+- [building](_pages/ClassesBuildings)
+- [creature](_pages/classesCreatures)
+- [miner](_pages/ClassesMiners)
+- [timer](_pages/ClassesTimer)
+- [vehicle](_pages/ClassesVehicles)
+
 It is good practice to declare your variables at the start of the script before any other code - but it is not required. The script parse engine will first make a pass through the script looking for all variables (and event chain names) and initializing them. Then it makes a second pass processing all of the triggers and Event Chains. Thus you can use variables and event chains prior to them being defined.
 
 Variables have a type followed by a single space followed by a name. The name should not be one of the reserved events and macros - [list of reserved words](_pages/ReservedWords). Variables have an optional initialization which is an equal sign after the name followed by the values(s).
+
 
 ## Variable Types
 
@@ -12,7 +22,7 @@ Variables can be of different types. Each type will only save certain values whi
 
 |Variable|Declaration|Comment|
 |----|----|----|
-|arrow|arrow MyArrow=color|To be used with [Arrow Events](_pages/Events). Color represents the color to highlight the tile beneth the arrow and can be one of the following: `black`, `blue`, `darkgreen`, `green`, `red`, `yellow`, `white`|
+|arrow|arrow MyArrow=color|To be used with Arrow Events. Color may  be one of the following: `black`, `blue`, `darkgreen`, `green`, `red`, `yellow`, `white`|
 |bool|bool HasFinishedTask=true|Saves true or false. Usable in conditions. Any initialization except "=true" is false. In Math events they are evaluated as 1 if true and 0 if false.|
 |building|building MyHQ=3,4|This binds the building with a footpoint located at row 3, column 4 to the variable name.|
 |creature|creature name=id|The creature identified by id is assigned to name|ex: creature PetMonster=5   Id's are from the creature section, the ID= field.|
@@ -33,23 +43,24 @@ You can dynamically change `miner`, `vehicle`, `building` and `creature` variabl
 
 ## Mixing Variable Types
 
-It is good programming practice to not mix bool and int variable types. For example, testing a bool variable to be > 0 - it works but not officially supported.  For bools the only logical operation types recommended are:
+It is poor programming practice to mix bool and int variable types. For example, testing a bool variable to be > 0 - it works but not officially supported.  For bools the only logical operation types recommended are:
 ```mms
 ((var==true))
 ((var==false))
 ((var!=true))
 ((var!=false))
 ```
-int and float types may freely be assigned to each other. Floats are truncated toward 0 when assigned to an int. bools should not be assigned to int but it does work, false is 0 and true is 1.
+int and float types may freely be assigned or tested with each other. Floats are truncated toward 0 when assigned to an int. bools should not be assigned to int but it does work, false is 0 and true is 1.
 
 Int and float values may be added to a string. For example:
 
 ```mms
-string s="The current game time: "
+string s=""
 float fNow=0.0
 
 init::;
 fNow=time;   # get game time as a float
+s="The current game time: "
 s+=fNow;     # append floating point number to string
 msg:s;       # display current game time
 ```
@@ -73,8 +84,6 @@ Variable names (and Event Chains names) should follow standard programming varia
 
 Technically the engine supports variables names (and Event Chains) that start with a numeric followed by at least one alpha but it is really poor practice to do this - it violates modern programming standards. You will find this style in only a few older maps and is strongly discouraged.
 
-## Timers
+As already stated above, variable names and event chain names must be unique and not one of the reserved words.  The script engine ignores case so variables cannot be unique by case alone. Even thou upper/lower case is ignored, it is a good practice to use case to improve readability.
 
-Periodic timers are created by either the visual block system or use of a timer variable. Once a timer is created, it will continue to fire on the given interval until the user exits the map. The interval values may be floating point numbers and the engine does support sub second timings. Naturally as timers fire faster or the more timers are active - internal overhead associated with them increases. That said, using timers is always more efficient than using the `tick` Event Chain.
 
-Using a timer variable allows use of `stoptimer` and `starttimer` events.

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -28,10 +28,13 @@
 <summary><b>Classes</b></summary>
 
 - [General Information](_pages/Classes)
+	- [Arrows](_pages/ClassesArrow)
 	- [Buildings](_pages/ClassesBuildings)
+	- [Creatures](_pages/classesCreatures)
 	- [Miners](_pages/ClassesMiners)
+	- [Timers](_pages/ClassesTimer)
 	- [Vehicles](_pages/ClassesVehicles)
-    - [Creatures](_pages/ClassesCreatures)
+
 
 </details>
 


### PR DESCRIPTION
Rework classes to remove curated references and to describe what properties are used in triggers and what are treated as macros.
New arrow and timer pages.
Lots of cleanup.